### PR TITLE
Bind built-in equality

### DIFF
--- a/Agda/Lecture-Notes/identity-type.lagda.md
+++ b/Agda/Lecture-Notes/identity-type.lagda.md
@@ -20,6 +20,8 @@ data _≡_ {A : Type} : A → A → Type where
  refl : (x : A) → x ≡ x
 
 infix 0 _≡_
+
+{-# BUILTIN EQUALITY _≡_ #-}
 ```
 
 ## Elimination principle


### PR DESCRIPTION
Allows using [with-abstraction equality](https://agda.readthedocs.io/en/v2.6.2.2/language/with-abstraction.html#with-abstraction-equality)