### PR TITLE
Support Agda 2.6.3

### DIFF
--- a/Agda/Cubical/cubical-prelude.lagda.md
+++ b/Agda/Cubical/cubical-prelude.lagda.md
@@ -9,8 +9,7 @@ module cubical-prelude where
 
 open import Agda.Builtin.Cubical.Path public
 open import Agda.Builtin.Cubical.Sub public
-  renaming ( inc to inS
-           ; primSubOut to outS
+  renaming ( primSubOut to outS
            )
 open import Agda.Primitive.Cubical public
   renaming ( primIMin       to _∧_  -- I → I → I
@@ -501,5 +500,3 @@ Bin→ℕ→Bin (binPos p)  = posInd localrefl (λ p _ → rem p) p
                                                               (localap sucPos (Pos→ℕ→Pos p))) ⟩
     binPos (sucPos p) ∎
 ```
-
-

--- a/Agda/HITs/Exercises5.lagda.md
+++ b/Agda/HITs/Exercises5.lagda.md
@@ -132,7 +132,7 @@ PathOver-endo≡ : ∀ {A : Type} {f : A → A}
                  {a a' : A} {p : a ≡ a'}
                  {q : (f a) ≡ a}
                  {r : (f a') ≡ a'}
-               → {!!}
+               → the Type {! !}
                → q ≡ r [ (\ x → f x ≡ x) ↓ p ]
 PathOver-endo≡ {p = (refl _)} {q = q} {r} h = {!!}
 

--- a/Agda/HITs/hits-lectures.agda-lib
+++ b/Agda/HITs/hits-lectures.agda-lib
@@ -1,2 +1,5 @@
 name: hits-lectures
 include: .
+flags:
+  --cubical-compatible
+  -WnoUnsupportedIndexedMatch

--- a/Agda/HITs/new-prelude.lagda.md
+++ b/Agda/HITs/new-prelude.lagda.md
@@ -144,4 +144,6 @@ data ℕ : Type where
  zero : ℕ
  suc  : ℕ → ℕ
 
+the : ∀ {l} (A : Type l) → A → A
+the _ x = x
 ```

--- a/Agda/Lecture-Notes/files/introduction.lagda.md
+++ b/Agda/Lecture-Notes/files/introduction.lagda.md
@@ -4,7 +4,7 @@ Notes originally written for the module *Advanced Functional Programming* of the
 
 <!--
 ```agda
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module introduction where
 ```

--- a/Agda/agda-lectures.agda-lib
+++ b/Agda/agda-lectures.agda-lib
@@ -4,3 +4,4 @@ include: Lecture-Notes/files
          Exercises
          Auxiliary
          Cubical
+flags: -WnoUnsupportedIndexedMatch

--- a/Agda/agda-lectures.agda-lib
+++ b/Agda/agda-lectures.agda-lib
@@ -4,4 +4,6 @@ include: Lecture-Notes/files
          Exercises
          Auxiliary
          Cubical
-flags: -WnoUnsupportedIndexedMatch
+flags:
+  -WnoUnsupportedIndexedMatch
+  --cubical-compatible


### PR DESCRIPTION
The `introduction` module needs to be marked `--cubical-compatible` as it is imported from the cubical prelude.

`inc` was renamed to `inS` in Agda.

Also tested with Agda 2.6.4.